### PR TITLE
Bug fix readpos function call mistakes.

### DIFF
--- a/crane_x7_control/src/dxlport_control.cpp
+++ b/crane_x7_control/src/dxlport_control.cpp
@@ -419,7 +419,7 @@ void DXLPORT_CONTROL::startup_motion( void )
     std::vector<ST_HOME_MOTION_DATA> home_motion_data;
 
     /* 開始位置取り込みと差分計算 */
-    readPos( t, d );
+    read( t, d );
 
     for( int jj=0 ; jj<joint_num ; ++jj ){
         ST_HOME_MOTION_DATA motion_work;
@@ -446,7 +446,7 @@ void DXLPORT_CONTROL::startup_motion( void )
     for( int step=0 ; step<step_max ; ++step ){
         d = getDuration(t);
         t = getTime();
-        readPos( t, d );
+        read( t, d );
         if( !port_stat ){
             for( int jj=0 ; jj<joint_num ; ++jj ){
                 if( joints[jj].get_ope_mode() == OPERATING_MODE_CURRENT ){


### PR DESCRIPTION
起動時に現在角度からホームポジションへ移動する仕様になっていますが、この処理において現在位置読み込みのために使用する関数が間違えており、ノード起動直後の値を使用していました。
意図通りの動作になるよう呼び出す関数を修正します。