### PR TITLE
Add run_depend(moveit_simple_controller_manager).

### DIFF
--- a/crane_x7_moveit_config/package.xml
+++ b/crane_x7_moveit_config/package.xml
@@ -19,6 +19,7 @@
   <run_depend>moveit_kinematics</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
   <run_depend>joint_state_publisher</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>xacro</run_depend>


### PR DESCRIPTION
実行時の依存関係に不足しているパッケージ（moveit_simple_controller_manager）を追加した。