### PR TITLE
Remove generate_messages from CMakeLists.txt

### DIFF
--- a/crane_x7_msgs/CMakeLists.txt
+++ b/crane_x7_msgs/CMakeLists.txt
@@ -7,11 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
   dynamic_reconfigure
   message_generation
 )
-generate_messages(
-  DEPENDENCIES
-  std_msgs
-  actionlib_msgs
-)
+
 generate_dynamic_reconfigure_options(
     cfg/ServoParameter.cfg
 )


### PR DESCRIPTION
#21に対応しました。
メッセージを生成していないので、generate_messagesを削除しています。

travis上でも、catkin_build時にWarningが発生しないことを確認しています。