### PR TITLE
Execute write_joint_param() once per a control loop

### DIFF
--- a/crane_x7_control/src/hardware.cpp
+++ b/crane_x7_control/src/hardware.cpp
@@ -284,7 +284,10 @@ int main( int argc, char* argv[] )
             crane_x7.set_gain( gain_data.dxl_id, gain_data.gain );
             set_gain_request.pop();
         }
-        while( set_joint_param_request.size() > 0 ){
+
+        // Dynamixelとの通信タイムアウトを防ぐため、
+        // write_joint_param()は1制御ループで1回のみ実行する
+        if( set_joint_param_request.size() > 0 ){
             write_joint_param( crane_x7, set_joint_param_request.front() );
             set_joint_param_request.pop();
         }


### PR DESCRIPTION
#73 を修正しました。
制御ループ１回につきwrite_joint_param()を**１回のみ**実行します。

Dynamixelとのタイムアウトがなくなるので、PIDゲインプリセット後もグリッパーの開閉が実行できるようになりました。