### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,8 @@ CRANE-X7の起動に必要なlaunchファイルをまとめたパッケージで
 
 ### crane_x7_examples
 
-初めて`crane_x7`を使うことを意識して作成されたbringupパッケージです。
-
-`crane_x7_examples` の使い方については[./crane_x7_examples/README.md](./crane_x7_examples/README.md)を参照してください。
+サンプルコード集です。
+使い方については[./crane_x7_examples/README.md](./crane_x7_examples/README.md)を参照してください。
 
 ### crane_x7_gazebo
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ CRANE-X7のROSパッケージです。
 ROS Wikiはこちらです。  
 [https://wiki.ros.org/crane_x7](https://wiki.ros.org/crane_x7)
 
+ROSのサンプルコード集はこちらです。  
+[crane_x7_examples](https://github.com/rt-net/crane_x7_ros/tree/master/crane_x7_examples)
+
 ## 動作環境
 
 以下の環境にて動作確認を行っています。

--- a/crane_x7_examples/README.md
+++ b/crane_x7_examples/README.md
@@ -102,7 +102,7 @@ CRANE-X7から20cm離れた位置にピッキング対象を設置します。
 
 サンプルで使用しているこのオレンジ色のソフトボールはRT ROBOT SHOPの[こちらのページ](https://www.rt-shop.jp/index.php?main_page=product_info&cPath=1299_1307&products_id=3701)から入手することができます。
 
-動作させると[こちら](https://youtu.be/_8xBgpgMhk8)のような動きになります。
+動作させると[こちら **(YouTube Video)**](https://youtu.be/_8xBgpgMhk8)のような動きになります。
 
 ---
 
@@ -120,7 +120,7 @@ CRANE-X7から20cm離れた位置にピッキング対象を設置します。
 roslaunch crane_x7_examples preset_pid_gain_example.launch
 ```
 
-動作させると[こちら](https://youtu.be/0rBbgNDwm6Y)のような動きになります。
+動作させると[こちら **(YouTube Video)**](https://youtu.be/0rBbgNDwm6Y)のような動きになります。
 
 ---
 
@@ -162,7 +162,7 @@ Teaching Modeから遷移します。トルクON*状態です。
 
 - トルクのON / OFFはサーボモータのPIDゲインに小さい値をプリセットすることで実現しています。
 
-動作させると[こちら](https://youtu.be/--5_l1DpQ-0)のような動きになります。
+動作させると[こちら **(YouTube Video)**](https://youtu.be/--5_l1DpQ-0)のような動きになります。
 
 ---
 
@@ -237,7 +237,7 @@ buttons: [0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 ---
 ```
 
-動作させると[こちら](https://youtu.be/IQci_vb3owM)のような動きになります。
+動作させると[こちら **(YouTube Video)**](https://youtu.be/IQci_vb3owM)のような動きになります。
 
 ---
 
@@ -336,7 +336,7 @@ Gazebo起動後、次のコマンドでサンプルを実行します。
 rosrun crane_x7_examples pick_and_place_in_gazebo_example.py
 ```
 
-動作させると[こちら](https://youtu.be/YUSIregHHnM)のような動きになります。
+動作させると[こちら **(YouTube Video)**](https://youtu.be/YUSIregHHnM)のような動きになります。
 
 ![gazebo_pick_and_place](https://github.com/rt-net/crane_x7_ros/blob/images/images/gazebo_pick_and_place.gif)
 

--- a/crane_x7_examples/README.md
+++ b/crane_x7_examples/README.md
@@ -322,8 +322,6 @@ rosrun crane_x7_examples servo_info_example.py
 
 ### pick_and_place_in_gazebo_example.pyの実行
 
-![gazebo_pick_and_place](https://github.com/rt-net/crane_x7_ros/blob/images/images/gazebo_pick_and_place.png "gazebo_pick_and_place")
-
 Gazebo上のモノを掴む・持ち上げる・運ぶ・置くコード例です。
 
 gripperをEffortControllerで制御するため、オプションを追加してGazeboを起動します。
@@ -339,4 +337,6 @@ rosrun crane_x7_examples pick_and_place_in_gazebo_example.py
 ```
 
 動作させると[こちら](https://youtu.be/YUSIregHHnM)のような動きになります。
+
+![gazebo_pick_and_place](https://github.com/rt-net/crane_x7_ros/blob/images/images/gazebo_pick_and_place.gif)
 

--- a/crane_x7_examples/README.md
+++ b/crane_x7_examples/README.md
@@ -285,7 +285,7 @@ roslaunch crane_x7_examples obstacle_avoidance_example.launch
 moveitが障害物回避のパスを生成できない場合、X7は動作せず、次の目標位置に対するパスを計算します。
 この場合、サーバからの返答は`result=False`となります。
 
-<img src="https://github.com/rt-net/crane_x7_ros/blob/images/images/obstacle_avoidance_1.png" width="400"><img src="https://github.com/rt-net/crane_x7_ros/blob/images/images/obstacle_avoidance_2.png" width="400">
+![gazebo_obstacle_avoidance](https://github.com/rt-net/crane_x7_ros/blob/images/images/gazebo_obstacle_avoidance.gif)
 
 ---
 

--- a/crane_x7_examples/README.md
+++ b/crane_x7_examples/README.md
@@ -78,6 +78,8 @@ SRDFファイル[crane_x7_moveit_config/config/crane_x7.srdf](../crane_x7_moveit
 rosrun crane_x7_examples pose_groupstate_example.py
 ```
 
+![pose_groupstate_example](https://github.com/rt-net/crane_x7_ros/blob/images/images/gazebo_pose_groupstate.gif)
+
 ---
 
 ### crane_x7_pick_and_place_demo.pyの実行

--- a/crane_x7_examples/README.md
+++ b/crane_x7_examples/README.md
@@ -61,6 +61,8 @@ roslaunch crane_x7_gazebo crane_x7_with_table.launch
 rosrun crane_x7_examples gripper_action_example.py
 ```
 
+![gripper_action_example](https://github.com/rt-net/crane_x7_ros/blob/images/images/gazebo_gripper_example.gif)
+
 ---
 
 ### pose_groupstate_example.pyの実行


### PR DESCRIPTION
パット見でサンプルがどのなものか理解できるように、
各サンプルをgazebo上で動かした場合のgitイメージをREADMEに追加します。

- [x] gripper_action_example.pyの実行
- [x] pose_groupstate_example.pyの実行
- [x] crane_x7_pick_and_place_demo.pyの実行　（すでにファイルがあるため不要）
- [x] preset_pid_gain_example.pyの実行　（プリセットできないため不要）
- [x] teaching_example.pyの実行　（PIDゲインをプリセットできないため不要）
- [x] joystick_example.pyの実行　（gazeboだとジョイスティックの操作が伝わりにくいので不要？）
- [x] obstacle_avoidance_example.pyの実行　（gazeboではなくrvizの映像を貼る）
- [x] servo_info_example.pyの実行　（実機専用のサンプルなので不要）
- [x] pick_and_place_in_gazebo_example.pyの実行

