### PR TITLE
Fix data length of GOAL_VELOCITY

### DIFF
--- a/crane_x7_control/include/crane_x7_control/joint_control.h
+++ b/crane_x7_control/include/crane_x7_control/joint_control.h
@@ -77,7 +77,7 @@ static const ST_DYNAMIXEL_REG_TABLE RegTable[] ={
     { "POSITION_P_GAIN",    84,     REG_LENGTH_WORD,  800,    enDXL_RAM,  false },
     { "BUS_WATCHDOG",       98,     REG_LENGTH_BYTE,  0,      enDXL_RAM,  false },
     { "GOAL_CURRENT",       102,    REG_LENGTH_WORD,  0,      enDXL_RAM,  false },
-    { "GOAL_VELOCITY",      104,    REG_LENGTH_WORD,  0,      enDXL_RAM,  false },
+    { "GOAL_VELOCITY",      104,    REG_LENGTH_DWORD, 0,      enDXL_RAM,  false },
     { "GOAL_POSITION",      116,    REG_LENGTH_DWORD, 0,      enDXL_RAM,  false },
     { "PRESENT_CURRENT",    126,    REG_LENGTH_WORD,  0,      enDXL_RAM,  false },
     { "PRESENT_VELOCITY",   128,    REG_LENGTH_DWORD, 0,      enDXL_RAM,  false },

--- a/crane_x7_control/include/crane_x7_control/joint_control.h
+++ b/crane_x7_control/include/crane_x7_control/joint_control.h
@@ -288,4 +288,3 @@ private:
     ST_JOINT_PARAM      param;
 };
 #endif /*DXL_JOINT_CONTROL_H */
-

--- a/crane_x7_control/include/crane_x7_control/joint_control.h
+++ b/crane_x7_control/include/crane_x7_control/joint_control.h
@@ -288,3 +288,4 @@ private:
     ST_JOINT_PARAM      param;
 };
 #endif /*DXL_JOINT_CONTROL_H */
+


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.

# What does this implement/fix? Explain your changes.
<!-- このPRはどんな機能改善/修正ですか？ -->

#116 の修正です。

Dynamixelの仕様と比較して、データサイズが4バイトであることを確認しています。
- https://emanual.robotis.com/docs/en/dxl/x/xm540-w270/
- https://emanual.robotis.com/docs/en/dxl/x/xm430-w350/

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

#116 