### PR TITLE
Add default scaling factors

### DIFF
--- a/crane_x7_examples/scripts/cartesian_path_example.py
+++ b/crane_x7_examples/scripts/cartesian_path_example.py
@@ -55,6 +55,7 @@ if __name__ == '__main__':
     robot = moveit_commander.RobotCommander()
     arm = moveit_commander.MoveGroupCommander("arm")
     arm.set_max_velocity_scaling_factor(0.1)
+    arm.set_max_acceleration_scaling_factor(1.0)
     gripper = moveit_commander.MoveGroupCommander("gripper")
 
     try:

--- a/crane_x7_examples/scripts/crane_x7_pick_and_place_demo.py
+++ b/crane_x7_examples/scripts/crane_x7_pick_and_place_demo.py
@@ -13,6 +13,7 @@ def main():
     robot = moveit_commander.RobotCommander()
     arm = moveit_commander.MoveGroupCommander("arm")
     arm.set_max_velocity_scaling_factor(0.1)
+    arm.set_max_acceleration_scaling_factor(1.0)
     gripper = moveit_commander.MoveGroupCommander("gripper")
 
     while len([s for s in rosnode.get_node_names() if 'rviz' in s]) == 0:

--- a/crane_x7_examples/scripts/joint_values_example.py
+++ b/crane_x7_examples/scripts/joint_values_example.py
@@ -10,6 +10,7 @@ def main():
     arm = moveit_commander.MoveGroupCommander("arm")
     # 駆動速度を調整する
     arm.set_max_velocity_scaling_factor(0.5)
+    arm.set_max_acceleration_scaling_factor(1.0)
 
     # SRDFに定義されている"vertical"の姿勢にする
     # すべてのジョイントの目標角度が0度になる

--- a/crane_x7_examples/scripts/joystick_example.py
+++ b/crane_x7_examples/scripts/joystick_example.py
@@ -224,6 +224,7 @@ def preset_pid_gain(pid_gain_no):
 def main():
     arm = moveit_commander.MoveGroupCommander("arm")
     arm.set_max_velocity_scaling_factor(0.5)
+    arm.set_max_acceleration_scaling_factor(1.0)
     gripper = moveit_commander.MoveGroupCommander("gripper")
 
     PRESET_DEFAULT  = 0

--- a/crane_x7_examples/scripts/obstacle_avoidance_example.py
+++ b/crane_x7_examples/scripts/obstacle_avoidance_example.py
@@ -20,6 +20,7 @@ def hook_shutdown():
     print('shutdown')
     arm = moveit_commander.MoveGroupCommander("arm")
     arm.set_max_velocity_scaling_factor(0.1)
+    arm.set_max_acceleration_scaling_factor(1.0)
     arm.set_named_target("vertical")
     arm.go()
 
@@ -29,6 +30,7 @@ def callback(req):
 
     arm = moveit_commander.MoveGroupCommander("arm")
     arm.set_max_velocity_scaling_factor(0.1)
+    arm.set_max_acceleration_scaling_factor(1.0)
     scene = moveit_commander.PlanningSceneInterface()
     rospy.sleep(SLEEP_TIME)
 

--- a/crane_x7_examples/scripts/pick_and_place_in_gazebo_example.py
+++ b/crane_x7_examples/scripts/pick_and_place_in_gazebo_example.py
@@ -47,6 +47,7 @@ def main():
 
     arm = moveit_commander.MoveGroupCommander("arm")
     arm.set_max_velocity_scaling_factor(0.4)
+    arm.set_max_acceleration_scaling_factor(1.0)
     gripper = actionlib.SimpleActionClient("crane_x7/gripper_controller/gripper_cmd", GripperCommandAction)
     gripper.wait_for_server()
     gripper_goal = GripperCommandGoal()

--- a/crane_x7_examples/scripts/pose_groupstate_example.py
+++ b/crane_x7_examples/scripts/pose_groupstate_example.py
@@ -13,6 +13,7 @@ def main():
     robot = moveit_commander.RobotCommander()
     arm = moveit_commander.MoveGroupCommander("arm")
     arm.set_max_velocity_scaling_factor(0.1)
+    arm.set_max_acceleration_scaling_factor(1.0)
     gripper = moveit_commander.MoveGroupCommander("gripper")
 
     while len([s for s in rosnode.get_node_names() if 'rviz' in s]) == 0:

--- a/crane_x7_examples/scripts/preset_pid_gain_example.py
+++ b/crane_x7_examples/scripts/preset_pid_gain_example.py
@@ -23,6 +23,7 @@ def main():
     rospy.init_node("preset_pid_gain_example")
     arm = moveit_commander.MoveGroupCommander("arm")
     arm.set_max_velocity_scaling_factor(0.3)
+    arm.set_max_acceleration_scaling_factor(1.0)
 
     while len([s for s in rosnode.get_node_names() if 'rviz' in s]) == 0:
         rospy.sleep(1.0)

--- a/crane_x7_examples/scripts/servo_info_example.py
+++ b/crane_x7_examples/scripts/servo_info_example.py
@@ -38,6 +38,7 @@ def main():
     rospy.init_node("joystick_example")
     arm = moveit_commander.MoveGroupCommander("arm")
     arm.set_max_velocity_scaling_factor(0.3)
+    arm.set_max_acceleration_scaling_factor(1.0)
     gripper = moveit_commander.MoveGroupCommander("gripper")
 
     # グリッパーを動かすサーボモータの電流値を取得

--- a/crane_x7_examples/scripts/teaching_example.py
+++ b/crane_x7_examples/scripts/teaching_example.py
@@ -83,6 +83,7 @@ def preset_pid_gain(pid_gain_no):
 def main():
     arm = moveit_commander.MoveGroupCommander("arm")
     arm.set_max_velocity_scaling_factor(0.5)
+    arm.set_max_acceleration_scaling_factor(1.0)
     gripper = moveit_commander.MoveGroupCommander("gripper")
 
     TORQUE_ON_PID = 0

--- a/crane_x7_moveit_config/config/joint_limits.yaml
+++ b/crane_x7_moveit_config/config/joint_limits.yaml
@@ -1,9 +1,11 @@
 # joint_limits.yaml allows the dynamics properties specified in the URDF to be overwritten or augmented as needed
 # Specific joint properties can be changed with the keys [max_position, min_position, max_velocity, max_acceleration]
 # Joint limits can be turned off with [has_velocity_limits, has_acceleration_limits]
+
+default_velocity_scaling_factor: 1.0
+default_acceleration_scaling_factor: 1.0
+
 joint_limits:
-  default_velocity_scaling_factor: 1.0
-  default_acceleration_scaling_factor: 1.0
   crane_x7_gripper_finger_a_joint:
     has_velocity_limits: true
     max_velocity: 4.81710873

--- a/crane_x7_moveit_config/config/joint_limits.yaml
+++ b/crane_x7_moveit_config/config/joint_limits.yaml
@@ -2,6 +2,8 @@
 # Specific joint properties can be changed with the keys [max_position, min_position, max_velocity, max_acceleration]
 # Joint limits can be turned off with [has_velocity_limits, has_acceleration_limits]
 joint_limits:
+  default_velocity_scaling_factor: 1.0
+  default_acceleration_scaling_factor: 1.0
   crane_x7_gripper_finger_a_joint:
     has_velocity_limits: true
     max_velocity: 4.81710873


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

#133 の対応です。

`joint_limits.yaml`に`default_acceleration_scaling_factor`と`default_velocity_scaling_factor`を追加し、Noetic環境でも、Melodic/Kinetic環境と同じ速度でX7を動かせるようにします。

`default_acceleration_scaling_factor`と`default_velocity_scaling_factor`は、ROSパラメータとしてセットされるため、
Melodic/Kinetic環境ではどのノードからも参照されず、悪影響を及ぼしません。

またPythonサンプルに` arm.set_max_acceleration_scaling_factor(1.0)`を追記しています。
これは、`default_*_scaling_factor`が`move_group_interface`に反映されないという不具合があるためです（参照：https://github.com/ros-planning/moveit/issues/2451
）

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

#133 

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

ROS NoeticとMelodicで、各サンプルを実行し、ほぼ同じ速度で動作していることを確認しました。

```sh
# Gazebo
$ roslaunch crane_x7_gazebo crane_x7_with_table.launch
$ rosrun crane_x7_examples joint_values_example.py
--- 以下、他のサンプルを実行 ---

# 実機
$ roslaunch crane_x7_bringup demo.launch fake_execution:=false
$ rosrun crane_x7_examples joint_values_example.py
--- 以下、他のサンプルを実行
```

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
