### PR TITLE
Disable shadows in gazebo world

### DIFF
--- a/crane_x7_gazebo/worlds/table.world
+++ b/crane_x7_gazebo/worlds/table.world
@@ -1,6 +1,9 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <world name="CRANE-X7 with Table">
+    <scene>
+      <shadows>0</shadows>
+    </scene>
 
     <include>
       <uri>model://sun</uri>


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

Gazeboの`shadows`をオフにして、明るくします。

Before:

![image](https://user-images.githubusercontent.com/18494952/101586657-bb916100-3a25-11eb-90f7-584ba2e89a62.png)

After:

![image](https://user-images.githubusercontent.com/18494952/101586686-cf3cc780-3a25-11eb-9ae4-113f95380a0f.png)

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
いいえ

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
Ubuntu 20.04、ROS Noetic環境で動作確認しました。


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
