### PR TITLE
Add collision model for joint covers and logos

### DIFF
--- a/crane_x7_description/urdf/crane_x7_arm.xacro
+++ b/crane_x7_description/urdf/crane_x7_arm.xacro
@@ -221,6 +221,14 @@
         </geometry>
         <material name="${shoulder_joint_cover_color}"/>
       </visual>
+
+      <collision>
+        <origin xyz="0 0 0" rpy="-${M_PI/2} 0 0"/>
+        <geometry>
+          <mesh filename="package://crane_x7_description/meshes/visual/joint_cover.stl"
+              scale="1 1 1"/>
+        </geometry>
+      </collision>
     </link>
 
     <!-- crane_x7_joint_cover_2_r -->
@@ -240,6 +248,14 @@
         </geometry>
         <material name="${shoulder_joint_cover_color}"/>
       </visual>
+
+      <collision>
+        <origin xyz="0 0 0" rpy="${M_PI/2} 0 0"/>
+        <geometry>
+          <mesh filename="package://crane_x7_description/meshes/visual/joint_cover.stl"
+              scale="1 1 1"/>
+        </geometry>
+      </collision>
     </link>
 
     <!-- crane_x7_joint_3 -->
@@ -371,6 +387,14 @@
         </geometry>
         <material name="${elbow_joint_cover_color}"/>
       </visual>
+
+      <collision>
+        <origin xyz="0 0 0" rpy="-${M_PI/2} 0 0"/>
+        <geometry>
+          <mesh filename="package://crane_x7_description/meshes/visual/joint_cover.stl"
+              scale="1 1 1"/>
+        </geometry>
+      </collision>
     </link>
 
     <!-- crane_x7_joint_cover_4_r -->
@@ -390,6 +414,14 @@
         </geometry>
         <material name="${elbow_joint_cover_color}"/>
       </visual>
+
+      <collision>
+        <origin xyz="0 0 0" rpy="${M_PI/2} 0 0"/>
+        <geometry>
+          <mesh filename="package://crane_x7_description/meshes/visual/joint_cover.stl"
+              scale="1 1 1"/>
+        </geometry>
+      </collision>
     </link>
 
     <!-- crane_x7_joint_5 -->

--- a/crane_x7_description/urdf/crane_x7_rt_logos.xacro
+++ b/crane_x7_description/urdf/crane_x7_rt_logos.xacro
@@ -14,6 +14,14 @@
           <color rgba="1.0 0.3 0.3 1.0"/>
         </material>
       </visual>
+
+      <collision>
+        <origin xyz="0 0 0" rpy="-${M_PI/2} ${M_PI/2} 0"/>
+        <geometry>
+          <mesh filename="package://crane_x7_description/meshes/visual/rtcorp_logo_name.stl"
+              scale="1 1 1"/>
+        </geometry>
+      </collision>
     </link>
     <joint name="${name}_logo_text_l_joint" type="fixed">
       <parent link="${parent}"/>
@@ -31,6 +39,14 @@
         </geometry>
         <material name="logo_red"/>
       </visual>
+
+      <collision>
+        <origin xyz="0 0 0" rpy="-${M_PI/2} ${M_PI/2} 0"/>
+        <geometry>
+          <mesh filename="package://crane_x7_description/meshes/visual/rtcorp_logo_rabbit.stl"
+              scale="1 1 1"/>
+        </geometry>
+      </collision>
     </link>
     <joint name="${name}_logo_symbol_l_joint" type="fixed">
       <parent link="${parent}"/>
@@ -48,6 +64,14 @@
         </geometry>
         <material name="logo_red"/>
       </visual>
+
+      <collision>
+        <origin xyz="0 0 0" rpy="${M_PI/2} -${M_PI/2} 0"/>
+        <geometry>
+          <mesh filename="package://crane_x7_description/meshes/visual/rtcorp_logo_name.stl"
+              scale="1 1 1"/>
+        </geometry>
+      </collision>
     </link>
     <joint name="${name}_logo_text_r_joint" type="fixed">
       <parent link="${parent}"/>
@@ -65,6 +89,13 @@
         </geometry>
         <material name="logo_red"/>
       </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="${M_PI/2} -${M_PI/2} 0"/>
+        <geometry>
+          <mesh filename="package://crane_x7_description/meshes/visual/rtcorp_logo_rabbit.stl"
+              scale="1 1 1"/>
+        </geometry>
+      </collision>
     </link>
     <joint name="${name}_logo_symbol_r_joint" type="fixed">
       <parent link="${parent}"/>


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

#136 の対応です。
xacroファイルを編集し、ジョイントカバーとロゴにcollision modelを追加します。

MoveItの仕様で、ROS Melodicまではcollision modelが設定されていない時Visual modelがコピーされていましたが、
Noeticからは警告が出るようになりました。

ROS Melodic:
https://github.com/ros-planning/moveit/blob/701fbddb26f5aa4e752235b893292fc4618da135/moveit_core/robot_model/src/robot_model.cpp#L1004-L1019

ROS Noetic(master):
https://github.com/ros-planning/moveit/blob/97c0b28f5580eadaade3f752f66f8eb12b0f7063/moveit_core/robot_model/src/robot_model.cpp#L1008-L1027

ジョイントカバーとロゴは衝突検出しないようにsrdfファイルで設定しているので、
collisionモデルを追加しても動作に影響は無いと考えられます。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

#136 

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

ROS Noetic、ROS Moveit環境で動かし、動作に変化が無いことを確認しました。

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
