### PR TITLE
Fix serial port settings description of crane_x7_control`s README.

### DIFF
--- a/crane_x7_control/README.md
+++ b/crane_x7_control/README.md
@@ -11,11 +11,10 @@ U2D2はLinuxに接続すると`/dev/ttyUSB0`として認識されるので、次
 sudo chmod 666 /dev/ttyUSB0
 ```
 
-CRANE-X7との接続に`/dev/ttyUSB0`以外を使用したい場合は、`crane_x7_control/config/crane_x7_control.yaml`に定義されているパラメータを変更することで設定することができます。
+CRANE-X7との接続に`/dev/ttyUSB0`以外（例：`/dev/ttyUSB1`）を使用したい場合は、次のようにコマンドを実行しします。
 
-```
-dynamixel_port:
-  port_name: "/dev/ttyUSB0"
+```bash
+roslaunch crane_x7_control crane_x7_control.launch port:=/dev/ttyUSB1
 ```
 
 ## 制御周期の変更

--- a/crane_x7_control/README.md
+++ b/crane_x7_control/README.md
@@ -11,8 +11,7 @@ U2D2はLinuxに接続すると`/dev/ttyUSB0`として認識されるので、次
 sudo chmod 666 /dev/ttyUSB0
 ```
 
-CRANE-X7との接続に`/dev/ttyUSB0`以外（例：`/dev/ttyUSB1`）を使用したい場合は、次のようにコマンドを実行しします。
-
+ケーブルの接続ポート名はデフォルトで`/dev/ttyUSB0`です。 別のポート名(例: `/dev/ttyUSB1`)を使う場合は次のコマンドを実行します。
 ```bash
 roslaunch crane_x7_control crane_x7_control.launch port:=/dev/ttyUSB1
 ```


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

crane_x7_controlパッケージのREADMEにある、シリアルポート設定の説明を修正します。

[crane_x7_control.yaml](https://github.com/rt-net/crane_x7_ros/blob/master/crane_x7_control/config/crane_x7_control.yaml)の`dynamixel_port/port_name`パラメータの値は、
[crane_x7_control.launch](https://github.com/rt-net/crane_x7_ros/blob/4e4ae927ee647676c2308debb2c074fc2926faea/crane_x7_control/launch/crane_x7_control.launch#L10)によって上書きされるため、yamlファイルを直接編集してもシリアルポートを変更できません。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
いいえ

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
文章変更のみです

# Any other comments?
<!-- その他コメントはありますか？ -->
いいえ

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
