### PR TITLE
roboticsgroup_gazebo_pluginsをroboticsgroup_upatras_gazebo_pluginsに変更する

### DIFF
--- a/.ci.rosinstall
+++ b/.ci.rosinstall
@@ -1,4 +1,0 @@
-- git:
-    local-name: roboticsgroup_gazebo_plugins
-    uri: https://github.com/roboticsgroup/roboticsgroup_gazebo_plugins.git
-    version: master

--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -27,8 +27,6 @@ jobs:
             experimental: true
           - env: { ROS_DISTRO: noetic, ROS_REPO: testing }
             experimental: true
-    env:
-      UPSTREAM_WORKSPACE: .ci.rosinstall
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/README.en.md
+++ b/README.en.md
@@ -59,9 +59,6 @@ Please see below for details.
   ```bash
   cd ~/catkin_ws/src
   
-  # package for crane_x7_gazebo
-  git clone https://github.com/roboticsgroup/roboticsgroup_gazebo_plugins.git
-  
   rosdep install -r -y --from-paths --ignore-src crane_x7_ros
   ```
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,6 @@ ROSのサンプルコード集はこちらです。
   ```bash
   cd ~/catkin_ws/src
   
-  # package for crane_x7_gazebo
-  git clone https://github.com/roboticsgroup/roboticsgroup_gazebo_plugins.git
-  
   rosdep install -r -y --from-paths --ignore-src crane_x7_ros
   ```
 

--- a/crane_x7_description/urdf/crane_x7_wide_two_finger_gripper.xacro
+++ b/crane_x7_description/urdf/crane_x7_wide_two_finger_gripper.xacro
@@ -133,7 +133,7 @@
 
     <!-- For gazebo simulation -->
     <gazebo>
-      <plugin name="crane_x7_gripper_mimic_joint" filename="libroboticsgroup_gazebo_mimic_joint_plugin.so">
+      <plugin name="crane_x7_gripper_mimic_joint" filename="libroboticsgroup_upatras_gazebo_mimic_joint_plugin.so">
         <joint>${name}_finger_a_joint</joint>
         <mimicJoint>${name}_finger_b_joint</mimicJoint>
         <multiplier>1</multiplier>

--- a/crane_x7_gazebo/package.xml
+++ b/crane_x7_gazebo/package.xml
@@ -18,7 +18,7 @@
   <exec_depend>gazebo</exec_depend>
   <exec_depend>gazebo_plugins</exec_depend>
   <exec_depend>gazebo_ros_control</exec_depend>
-  <exec_depend>roboticsgroup_gazebo_plugins</exec_depend>
+  <exec_depend>roboticsgroup_upatras_gazebo_plugins</exec_depend>
   <exec_depend>roslang</exec_depend>
   <exec_depend>urdf_parser_plugin</exec_depend>
 


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

#132 を修正するPRです。

https://github.com/roboticsgroup/roboticsgroup_gazebo_plugins
が使用非推奨になったため、

https://github.com/roboticsgroup/roboticsgroup_upatras_gazebo_plugins
に移行します。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

#132 をクローズします。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

ROS MelodicとNoeticのGazebo環境でグリッパが動作することを確認しました。

```sh
$ roslaunch crane_x7_gazebo crane_x7_with_table.launch

$ rosrun crane_x7_examples pick_and_place_in_gazebo_example.py
```

# Any other comments?
<!-- その他コメントはありますか？ -->
いいえ

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
