### PR TITLE
パラメータ名をstall_velocity_thresholdに修正

### DIFF
--- a/crane_x7_control/README.md
+++ b/crane_x7_control/README.md
@@ -92,7 +92,7 @@ gripper_controller:
 +    crane_x7_gripper_finger_a_joint: { p: 1.0, i: 0.01, d: 0.1 }
   action_monitor_rate: 10
   state_publish_rate:  100
-  stalled_velocity_threshold: 0.01
+  stall_velocity_threshold: 0.01
   goal_tolerance: 0.2
   stall_timeout: 0.3
 

--- a/crane_x7_control/config/crane_x7_control.yaml
+++ b/crane_x7_control/config/crane_x7_control.yaml
@@ -24,7 +24,7 @@ gripper_controller:
   joint: crane_x7_gripper_finger_a_joint
   action_monitor_rate: 10
   state_publish_rate:  100
-  stalled_velocity_threshold: 0.01
+  stall_velocity_threshold: 0.01
   goal_tolerance: 0.2
   stall_timeout: 0.3
 

--- a/crane_x7_control/config/crane_x7_fake_control.yaml
+++ b/crane_x7_control/config/crane_x7_fake_control.yaml
@@ -25,7 +25,7 @@ gripper_controller:
   joint: crane_x7_gripper_finger_a_joint
   action_monitor_rate: 50
   state_publish_rate:  100
-  stalled_velocity_threshold: 0.01
+  stall_velocity_threshold: 0.01
   goal_tolerance: 0.2
   stall_timeout: 0.3
 


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

https://github.com/rt-net/sciurus17_ros/pull/124 と同じ修正です。

GriiperActionControllerのパラメータ名を`stalled_velocity_threshold`から`stall_velocity_threshold`に変更します。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
いいえ

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

パラメータ名修正後に`rosrun crane_x7_examples gripper_action_example.py`を実行し、Gripperが動くことを確認しました。

また、下記のようにthresholdの数値を大きくし、グリッパサンプルを実行します。
そのときに、グリッパの開閉を手で妨害すると、stalled判定になることを確認しました。

```diff
gripper_controller:
  type: "position_controllers/GripperActionController"
  publish_rate: 250
  joint: crane_x7_gripper_finger_a_joint
  action_monitor_rate: 10
  state_publish_rate:  100
+ stall_velocity_threshold: 10
  goal_tolerance: 0.2
  stall_timeout: 0.3
```

実行結果：

```sh
$ rosrun crane_x7_examples gripper_action_example.py
Open Gripper.
position: 0.32213596545598466
effort: 1.0
stalled: True
reached_goal: False

Close Gripper.
position: 0.06135923151542565
effort: 1.0
stalled: False
reached_goal: True
```

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
