### PR TITLE
launch時のwarning消すための修正

### DIFF
--- a/crane_x7_moveit_config/config/crane_x7.srdf
+++ b/crane_x7_moveit_config/config/crane_x7.srdf
@@ -40,7 +40,6 @@
     <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
     <end_effector name="end_effector" parent_link="crane_x7_gripper_base_link" group="gripper" />
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
-    <virtual_joint name="table" type="fixed" parent_frame="world" child_link="base_link" />
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
     <disable_collisions link1="crane_x7_gripper_base_link" link2="crane_x7_gripper_finger_a_link" reason="Adjacent" />
     <disable_collisions link1="crane_x7_gripper_base_link" link2="crane_x7_gripper_finger_b_link" reason="Adjacent" />

--- a/crane_x7_moveit_config/config/kinematics.yaml
+++ b/crane_x7_moveit_config/config/kinematics.yaml
@@ -2,4 +2,3 @@ arm:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 3

--- a/crane_x7_moveit_config/launch/move_group.launch
+++ b/crane_x7_moveit_config/launch/move_group.launch
@@ -28,9 +28,11 @@
   <arg name="port" default="/dev/ttyUSB0" />
 
   <!-- Planning Functionality -->
-  <include ns="move_group" file="$(find crane_x7_moveit_config)/launch/planning_pipeline.launch.xml">
-    <arg name="pipeline" value="ompl" />
-  </include>
+  <group ns="move_group/planning_pipelines">
+    <include ns="ompl" file="$(find crane_x7_moveit_config)/launch/planning_pipeline.launch.xml">
+      <arg name="pipeline" value="ompl" />
+    </include>
+  </group>
 
   <!-- Trajectory Execution Functionality -->
   <include ns="move_group" file="$(find crane_x7_moveit_config)/launch/trajectory_execution.launch.xml" if="$(arg allow_trajectory_execution)">
@@ -60,6 +62,7 @@
     <param name="max_safe_path_cost" value="$(arg max_safe_path_cost)"/>
     <param name="jiggle_fraction" value="$(arg jiggle_fraction)" />
 
+    <param name="default_planning_pipeline" value="ompl" />
     <!-- load these non-default MoveGroup capabilities -->
     <!--
     <param name="capabilities" value="

--- a/crane_x7_moveit_config/launch/move_group.launch
+++ b/crane_x7_moveit_config/launch/move_group.launch
@@ -28,11 +28,9 @@
   <arg name="port" default="/dev/ttyUSB0" />
 
   <!-- Planning Functionality -->
-  <group ns="move_group/planning_pipelines">
-    <include ns="ompl" file="$(find crane_x7_moveit_config)/launch/planning_pipeline.launch.xml">
-      <arg name="pipeline" value="ompl" />
-    </include>
-  </group>
+  <include ns="move_group" file="$(find crane_x7_moveit_config)/launch/planning_pipeline.launch.xml">
+    <arg name="pipeline" value="ompl" />
+  </include>
 
   <!-- Trajectory Execution Functionality -->
   <include ns="move_group" file="$(find crane_x7_moveit_config)/launch/trajectory_execution.launch.xml" if="$(arg allow_trajectory_execution)">
@@ -62,7 +60,6 @@
     <param name="max_safe_path_cost" value="$(arg max_safe_path_cost)"/>
     <param name="jiggle_fraction" value="$(arg jiggle_fraction)" />
 
-    <param name="default_planning_pipeline" value="ompl" />
     <!-- load these non-default MoveGroup capabilities -->
     <!--
     <param name="capabilities" value="


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

https://github.com/rt-net/sciurus17_ros/pull/122 と同じ変更です。

launch時のwarningを消すための修正です。機能変更はありません。

## kinematics.yaml

Melodic版のMoveItから、kinematicsプラグインのkinematics_solver_attemptsオプションが削除されます。
そのため、kinematics.yamlからオプションを削除します。

参考：https://github.com/ros-planning/moveit/blob/master/MIGRATION.md#ros-melodic

対象のwarning:

`Kinematics solver doesn't support #attempts anymore, but only a timeout. Please remove the parameter '/robot_description_kinematics/r_arm_group/kinematics_solver_attempts' from your configuration.`

## crane_x7.srdf

crane_x7.srdfで定義されているtableジョイントはmoveitから無視されているので、定義をコメントアウトします。

対象のwarning:

`Skipping virtual joint 'table' because its child frame 'base_link' does not match the URDF frame 'world'`



# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
いいえ

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

ROS Melodic、Noetic環境にて、RVizのGUIを用いて、実機とGazeboのCRANE-X7を動かせることを確認しました。

```sh
$ roslaunch crane_x7_bringup demo.launch fake_execution:=false

$ roslaunch crane_x7_gazebo crane_x7_with_table.launch 
```

# Any other comments?
<!-- その他コメントはありますか？ -->

https://github.com/ros-planning/moveit/pull/2127 より、ROS Noeticから複数のplanning pipelineが同時設定できるようになったようです。
これにより、デフォルトで使用するplanning pipelineがパラメータで指定されていないとwarningが表示されます。

- `MoveGroup launched without ~default_planning_pipeline specifying the namespace for the default planning pipeline configuration`
- `Falling back to using the the move_group node namespace (deprecated behavior).`

2d99307f9f02a316acabb2b9a0c75e8bdcdba560 での変更のように、
move_group.launchに`default_planning_pipeline`パラメータを追加し、
planning_pipelineパラメータの名前空間を`move_group/planning_pipelines/(プランナ名)`に変えることで、
この問題を解決できます。
しかし、パラメータの名前空間変えた影響か、Melodic環境で動作しなくなったため、この修正は取り入れません。（Revertしました）

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
