### PR TITLE
Remove definition of controller that has already been loaded

### DIFF
--- a/crane_x7_control/launch/crane_x7_fake_control.launch
+++ b/crane_x7_control/launch/crane_x7_fake_control.launch
@@ -17,11 +17,4 @@
     <rosparam file="$(find crane_x7_control)/config/crane_x7_gazebo_control.yaml" command="load" />
   </group>
 
-  <node name="controller_gazebo" 
-    pkg="controller_manager" 
-    type="spawner" 
-    respawn="false" 
-    output="screen"
-    args="gazebo_ros_control" />
-
 </launch>


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

gazebo_ros_controlをspawnできないという以下の警告を解消するものです

```
[WARN] [1648875337.082548, 27.536000]: Controller Spawner couldn't find the expected controller_manager ROS interface.
[controller_gazebo-3] process has finished cleanly
```


# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

Fix #150 

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

1. `git checkout feature/fix-gazebo-ros-control-launch-error`
2. `roslaunch crane_x7_gazebo crane_x7_with_table.launch` を実行する
3. MoveItが起動してから10秒〜1分ほど待つ
4. `Controller Spawner couldn't find the expected controller_manager ROS interface.`と警告が表示されず、また`Loading gazebo_ros_control plugin` `Starting gazebo_ros_control plugin in namespace: /crane_x7`とログに表示されることを確認する

# Any other comments?
<!-- その他コメントはありますか？ -->

http://gazebosim.org/tutorials/?tut=ros_control

上記のチュートリアルでも`controller_manager/spawner`でgazebo_ros_controlを指定していないので、URDF（XACRO）から呼び出すros_controlのプラグインについては、別途呼び出しが不要のようです。

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
