### PR TITLE
Add an option overriding URDF to launch

### DIFF
--- a/crane_x7_control/launch/crane_x7_control.launch
+++ b/crane_x7_control/launch/crane_x7_control.launch
@@ -1,8 +1,9 @@
 <launch>
   <!-- USB port name for dynamixel_port -->
   <arg name="port" default="/dev/ttyUSB0" />
+  <arg name="load_robot_description" default="true" />
 
-  <param name="robot_description"
+  <param if="$(arg load_robot_description)" name="robot_description"
     command="$(find xacro)/xacro --inorder '$(find crane_x7_description)/urdf/crane_x7.urdf.xacro'"
     />
   <group ns="crane_x7">

--- a/crane_x7_moveit_config/launch/demo.launch
+++ b/crane_x7_moveit_config/launch/demo.launch
@@ -57,6 +57,7 @@
     <arg name="debug" value="$(arg debug)"/>
     <arg name="port" value="$(arg port)" />
     <arg name="use_gazebo" value="$(arg use_gazebo)"/>
+    <arg name="load_robot_description" value="$(arg load_robot_description)"/>
   </include>
 
   <!-- Run Rviz and load the default config to see the state of the move_group node -->

--- a/crane_x7_moveit_config/launch/move_group.launch
+++ b/crane_x7_moveit_config/launch/move_group.launch
@@ -1,6 +1,9 @@
 <launch>
 
   <arg name="use_gazebo" default="false" />
+  <!-- By default the URDF is loaded in crane_x7_control if fake_control==false. -->
+  <!-- Change the following to false to change the default behavior. -->
+  <arg name="load_robot_description" default="true"/>
 
   <include file="$(find crane_x7_moveit_config)/launch/planning_context.launch" />
 
@@ -43,6 +46,7 @@
     <!-- If fake==false, launch X7 controller -->
     <include file="$(find crane_x7_control)/launch/crane_x7_control.launch" unless="$(arg fake_execution)">
       <arg name="port" value="$(arg port)" />
+      <arg name="load_robot_description" value="$(arg load_robot_description)" />
     </include>
   </group>
 


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

`crane_x7_moveit_config/launch/demo.launch`には`load_robot_description`オプションがあります。

https://github.com/rt-net/crane_x7_ros/blob/a214df2c4ff1fa8a1cf535305afb1adcc129410b/crane_x7_moveit_config/launch/demo.launch#L4

しかし、ここをfalseにした場合でも`use_gazebo`がfalseの場合は`crane_x7_control/launch/crane_x7_control`でrobot_descriptionが定義されており、`load_robot_description`が常にtrueになってしまいます。

`crane_x7_moveit_config/launch/demo.launch` --> `crane_x7_moveit_config/launch/move_group.launch` -->  `crane_x7_control/launch/crane_x7_control` の順で呼び出されます。

https://github.com/rt-net/crane_x7_ros/blob/a214df2c4ff1fa8a1cf535305afb1adcc129410b/crane_x7_control/launch/crane_x7_control.launch#L5-L7

これを修正します。

ちなみに`crane_x7_moveit_config/launch/demo.launch` --> `crane_x7_moveit_config/launch/planning_context.launch`は`load_robot_description`が渡されるようになっています。

https://github.com/rt-net/crane_x7_ros/blob/a214df2c4ff1fa8a1cf535305afb1adcc129410b/crane_x7_moveit_config/launch/demo.launch#L31-L33

https://github.com/rt-net/crane_x7_ros/blob/a214df2c4ff1fa8a1cf535305afb1adcc129410b/crane_x7_moveit_config/launch/planning_context.launch#L9


# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

しません

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->



# Any other comments?
<!-- その他コメントはありますか？ -->

ハードウェアを改造したCRANE-X7実機を動かす際に必要になるオプションなので使われるケースは少ないと思います。

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
