### PR TITLE
サンプル実行時の初期姿勢を追加

### DIFF
--- a/crane_x7_examples/src/gripper_control.cpp
+++ b/crane_x7_examples/src/gripper_control.cpp
@@ -31,17 +31,26 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
   rclcpp::NodeOptions node_options;
   node_options.automatically_declare_parameters_from_overrides(true);
+  auto move_group_arm_node = rclcpp::Node::make_shared("move_group_arm_node", node_options);
   auto move_group_gripper_node = rclcpp::Node::make_shared("move_group_gripper_node", node_options);
   // For current state monitor
   rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(move_group_arm_node);
   executor.add_node(move_group_gripper_node);
   std::thread([&executor]() {executor.spin();}).detach();
+
+  MoveGroupInterface move_group_arm(move_group_arm_node, "arm");
+  move_group_arm.setMaxVelocityScalingFactor(1.0);  // Set 0.0 ~ 1.0
+  move_group_arm.setMaxAccelerationScalingFactor(1.0);  // Set 0.0 ~ 1.0
 
   MoveGroupInterface move_group_gripper(move_group_gripper_node, "gripper");
   move_group_gripper.setMaxVelocityScalingFactor(1.0);  // Set 0.0 ~ 1.0
   move_group_gripper.setMaxAccelerationScalingFactor(1.0);  // Set 0.0 ~ 1.0
-
   auto gripper_joint_values = move_group_gripper.getCurrentJointValues();
+
+  // SRDFに定義されている"home"の姿勢にする
+  move_group_arm.setNamedTarget("home");
+  move_group_arm.move();
 
   gripper_joint_values[0] = angles::from_degrees(60);
   move_group_gripper.setJointValueTarget(gripper_joint_values);

--- a/crane_x7_examples/src/pick_and_place.cpp
+++ b/crane_x7_examples/src/pick_and_place.cpp
@@ -55,14 +55,14 @@ int main(int argc, char ** argv)
   double GRIPPER_OPEN = angles::from_degrees(60.0);
   double GRIPPER_CLOSE = angles::from_degrees(20);
 
+  // SRDFに定義されている"home"の姿勢にする
+  move_group_arm.setNamedTarget("home");
+  move_group_arm.move();
+
   // 何かを掴んでいた時のためにハンドを開く
   gripper_joint_values[0] = GRIPPER_OPEN;
   move_group_gripper.setJointValueTarget(gripper_joint_values);
   move_group_gripper.move();
-
-  // SRDFに定義されている"home"の姿勢にする
-  move_group_arm.setNamedTarget("home");
-  move_group_arm.move();
 
   // 可動範囲を制限する
   moveit_msgs::msg::Constraints constraints;
@@ -95,11 +95,6 @@ int main(int argc, char ** argv)
   target_pose.orientation = tf2::toMsg(q);
   move_group_arm.setPoseTarget(target_pose);
   move_group_arm.move();
-
-  // ハンドを開く
-  gripper_joint_values[0] = GRIPPER_OPEN;
-  move_group_gripper.setJointValueTarget(gripper_joint_values);
-  move_group_gripper.move();
 
   // 掴みに行く
   target_pose.position.x = 0.2;


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
サンプル実行直後にグリッパが開閉すると危険なためhome姿勢に移行してからグリッパの開閉を行うように変更しました。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
gripper_controlとpick_and_placeのサンプルを実行し、home姿勢に移行してからグリッパの開閉を行うことを確認しました。

# Any other comments?
<!-- その他コメントはありますか？ -->
ないです

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
