### PR TITLE
RealSense D435搭載モデルに対応

### DIFF
--- a/crane_x7_examples/README.md
+++ b/crane_x7_examples/README.md
@@ -50,7 +50,7 @@ ros2 launch crane_x7_examples demo.launch.py port_name:=/dev/ttyUSB0
 ```
 
 #### RealSense D435マウンタ搭載モデルを使用する場合
-[RealSense D435マウンタ](https://github.com/rt-net/crane_x7_Hardware/blob/master/3d_print_parts/v1.0/CRANE-X7_HandA_RealSenseD435%E3%83%9E%E3%82%A6%E3%83%B3%E3%82%BF.stl)を搭載している場合は次のコマンドを実行します。RealSense D435が起動し、camera_linkがロボットモデルに追加されます。
+[RealSense D435マウンタ](https://github.com/rt-net/crane_x7_Hardware/blob/master/3d_print_parts/v1.0/CRANE-X7_HandA_RealSenseD435マウンタ.stl)を搭載している場合は次のコマンドを実行します。RealSense D435が起動し、camera_linkがロボットモデルに追加されます。
 
 ```sh
 ros2 launch crane_x7_examples demo.launch.py port_name:=/dev/ttyUSB0 use_d435:=true

--- a/crane_x7_examples/README.md
+++ b/crane_x7_examples/README.md
@@ -2,6 +2,25 @@
 
 このパッケージはCRANE-X7 ROS 2パッケージのサンプルコード集です。
 
+- [crane_x7_examples](#crane_x7_examples)
+  - [準備（実機を使う場合）](#準備実機を使う場合)
+    - [1. CRANE-X7本体をPCに接続する](#1-crane-x7本体をpcに接続する)
+    - [2. USB通信ポートの接続を確認する](#2-usb通信ポートの接続を確認する)
+    - [3. move_groupとcontrollerを起動する](#3-move_groupとcontrollerを起動する)
+      - [標準モデルを使用する場合](#標準モデルを使用する場合)
+      - [RealSense D435マウンタ搭載モデルを使用する場合](#realsense-d435マウンタ搭載モデルを使用する場合)
+  - [準備 (Gazeboを使う場合)](#準備-gazeboを使う場合)
+    - [1. move_groupとGazeboを起動する](#1-move_groupとgazeboを起動する)
+  - [サンプルプログラムを実行する](#サンプルプログラムを実行する)
+  - [Examples](#examples)
+    - [gripper_control](#gripper_control)
+    - [pose_groupstate](#pose_groupstate)
+    - [joint_values](#joint_values)
+    - [cartesian_path](#cartesian_path)
+      - [Videos](#videos)
+    - [pick_and_place](#pick_and_place)
+      - [Videos](#videos-1)
+
 ## 準備（実機を使う場合）
 
 ![crane_x7](https://rt-net.github.io/images/crane-x7/CRANE-X7-500x500.png)
@@ -22,11 +41,19 @@ USB通信ポートの設定については`crane_x7_control`の
 
 ### 3. move_groupとcontrollerを起動する
 
+#### 標準モデルを使用する場合
 次のコマンドでmove_group (`crane_x7_moveit_config`)と
 controller (`crane_x7_control`)を起動します。
 
 ```sh
 ros2 launch crane_x7_examples demo.launch.py port_name:=/dev/ttyUSB0
+```
+
+#### RealSense D435マウンタ搭載モデルを使用する場合
+[RealSense D435マウンタ](https://github.com/rt-net/crane_x7_Hardware/blob/master/3d_print_parts/v1.0/CRANE-X7_HandA_RealSenseD435%E3%83%9E%E3%82%A6%E3%83%B3%E3%82%BF.stl)を搭載している場合は次のコマンドを実行します。RealSense D435が起動し、camera_linkがロボットモデルに追加されます。
+
+```sh
+ros2 launch crane_x7_examples demo.launch.py port_name:=/dev/ttyUSB0 use_d435:=true
 ```
 
 ## 準備 (Gazeboを使う場合)

--- a/crane_x7_examples/launch/demo.launch.py
+++ b/crane_x7_examples/launch/demo.launch.py
@@ -78,7 +78,7 @@ def generate_launch_description():
                 '/launch/crane_x7_control.launch.py']),
             launch_arguments={'loaded_description': description}.items()
         )
-    
+
     realsense_node = IncludeLaunchDescription(
             PythonLaunchDescriptionSource([
                 get_package_share_directory('realsense2_camera'),

--- a/crane_x7_examples/launch/demo.launch.py
+++ b/crane_x7_examples/launch/demo.launch.py
@@ -86,7 +86,7 @@ def generate_launch_description():
             condition=IfCondition(LaunchConfiguration('use_d435')),
             launch_arguments={
                 'device_type': 'd435',
-                'pointcloud.enable' : 'true',
+                'pointcloud.enable': 'true',
             }.items()
         )
 

--- a/crane_x7_examples/package.xml
+++ b/crane_x7_examples/package.xml
@@ -19,6 +19,7 @@
   <depend>geometry_msgs</depend>
   <depend>moveit_ros_planning_interface</depend>
   <depend>rclcpp</depend>
+  <depend>realsense2_camera</depend>
   <depend>tf2_geometry_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/crane_x7_gazebo/launch/crane_x7_with_table.launch.py
+++ b/crane_x7_gazebo/launch/crane_x7_with_table.launch.py
@@ -17,13 +17,21 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from crane_x7_description.robot_description_loader import RobotDescriptionLoader
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
 from launch.actions import ExecuteProcess
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
+    declare_use_d435 = DeclareLaunchArgument(
+        'use_d435',
+        default_value='false',
+        description='Use d435.'
+    )
+
     # PATHを追加で通さないとSTLファイルが読み込まれない
     env = {'IGN_GAZEBO_SYSTEM_PLUGIN_PATH': os.environ['LD_LIBRARY_PATH'],
            'IGN_GAZEBO_RESOURCE_PATH': os.path.dirname(
@@ -52,6 +60,7 @@ def generate_launch_description():
 
     description_loader = RobotDescriptionLoader()
     description_loader.use_gazebo = 'true'
+    description_loader.use_d435 = LaunchConfiguration('use_d435')
     description_loader.gz_control_config_package = 'crane_x7_control'
     description_loader.gz_control_config_file_path = 'config/crane_x7_controllers.yaml'
     description = description_loader.load()
@@ -82,6 +91,7 @@ def generate_launch_description():
             )
 
     return LaunchDescription([
+        declare_use_d435,
         ign_gazebo,
         ignition_spawn_entity,
         move_group,

--- a/crane_x7_gazebo/launch/crane_x7_with_table.launch.py
+++ b/crane_x7_gazebo/launch/crane_x7_with_table.launch.py
@@ -17,21 +17,13 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from crane_x7_description.robot_description_loader import RobotDescriptionLoader
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
 from launch.actions import ExecuteProcess
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
-    declare_use_d435 = DeclareLaunchArgument(
-        'use_d435',
-        default_value='false',
-        description='Use d435.'
-    )
-
     # PATHを追加で通さないとSTLファイルが読み込まれない
     env = {'IGN_GAZEBO_SYSTEM_PLUGIN_PATH': os.environ['LD_LIBRARY_PATH'],
            'IGN_GAZEBO_RESOURCE_PATH': os.path.dirname(
@@ -60,7 +52,6 @@ def generate_launch_description():
 
     description_loader = RobotDescriptionLoader()
     description_loader.use_gazebo = 'true'
-    description_loader.use_d435 = LaunchConfiguration('use_d435')
     description_loader.gz_control_config_package = 'crane_x7_control'
     description_loader.gz_control_config_file_path = 'config/crane_x7_controllers.yaml'
     description = description_loader.load()
@@ -91,7 +82,6 @@ def generate_launch_description():
             )
 
     return LaunchDescription([
-        declare_use_d435,
         ign_gazebo,
         ignition_spawn_entity,
         move_group,


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
RealSense D435搭載モデルに対応するためにdemo.launch起動時の引数`use_d435`を追加しました。
`use_d435:=true`時にRealSenseが起動し、ロボットモデルにcamera_linkが追加されます。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
下記コマンドを実行してRealSenseの起動とロボットモデルにcamera_linkが追加、RVizで点群が可視化されることを確認しています。
```
ros2 launch crane_x7_examples demo.launch.py use_d435:=true
```

Gazeboでのカメラのシミュレーションは未対応のためモデルとフレームだけ追加されます。

```
ros2 launch crane_x7_gazebo crane_x7_with_table.launch.py use_d435:=true
```

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
