### PR TITLE
goal_toleranceの設定と把持角の調整

### DIFF
--- a/crane_x7_control/config/crane_x7_controllers.yaml
+++ b/crane_x7_control/config/crane_x7_controllers.yaml
@@ -29,6 +29,7 @@ crane_x7_arm_controller:
 crane_x7_gripper_controller:
   ros__parameters:
     joint: crane_x7_gripper_finger_a_joint
+    goal_tolerance: 0.1
 
     command_interfaces:
       - position

--- a/crane_x7_examples/src/pick_and_place_tf.cpp
+++ b/crane_x7_examples/src/pick_and_place_tf.cpp
@@ -163,7 +163,7 @@ private:
   {
     const double GRIPPER_DEFAULT = 0.0;
     const double GRIPPER_OPEN = angles::from_degrees(60.0);
-    const double GRIPPER_CLOSE = angles::from_degrees(15.0);
+    const double GRIPPER_CLOSE = angles::from_degrees(20.0);
 
     // 何かを掴んでいた時のためにハンドを開閉
     control_gripper(GRIPPER_OPEN);


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
pick_and_placeやカメラサンプルにてオブジェクト把持時に下記エラーが出ていたため、以下の変更をしました。
- goal_toleranceの設定
  - 0.1 radの差分をグリッパ角の許容値としました。
- 把持角の調整
  - カメラサンプルの把持角を15度から20度に変更しました。これはpick_and_placeサンプルの把持角と統一し、エラーが出力される条件を揃えるためです。

```
[pick_and_place_tf-1] [ERROR] [1697448073.978872967] [move_group_interface]: MoveGroupInterface::move() failed or timeout reached
```

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
#191 をcloseします。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

下記コマンドでpick_and_placeを実行し、上記エラーが出力されないことを確認しました。
```
ros2 launch crane_x7_examples demo.launch.py
ros2 launch crane_x7_examples example.launch.py example:='pick_and_place'
```

下記コマンドでカメラサンプルを実行し、上記エラーが出力されないことを確認しました。

```
ros2 launch crane_x7_examples demo.launch.py use_d435:=true
ros2 launch crane_x7_examples camera_example.launch.py example:='aruco_detection'
```

# Any other comments?
<!-- その他コメントはありますか？ -->
ないです

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
