### PR TITLE
joint_values.pyで初期姿勢のjointを取得して動作に反映するように修正

### DIFF
--- a/crane_x7_examples_py/crane_x7_examples_py/joint_values.py
+++ b/crane_x7_examples_py/crane_x7_examples_py/joint_values.py
@@ -48,7 +48,9 @@ def main(args=None):
     )
 
     # 動作速度の調整
-    arm_plan_request_params.max_acceleration_scaling_factor = 0.5  # Set 0.0 ~ 1.0
+    arm_plan_request_params.max_acceleration_scaling_factor = (
+        0.5  # Set 0.0 ~ 1.0
+    )
     arm_plan_request_params.max_velocity_scaling_factor = 0.5  # Set 0.0 ~ 1.0
 
     # SRDFに定義されている'vertical'の姿勢にする
@@ -69,7 +71,7 @@ def main(args=None):
         'crane_x7_lower_arm_fixed_part_joint',
         'crane_x7_lower_arm_revolute_part_joint',
         'crane_x7_wrist_joint',
-        ]
+    ]
     target_joint_value = math.radians(-45.0)
 
     # 現在角度をベースに、目標角度を作成する
@@ -78,17 +80,18 @@ def main(args=None):
 
     # jointのリストを辞書型の形式に変換する
     joint_values_dict = dict(zip(joint_names, joint_values))
-    
+
     # 各関節角度を順番に-45[deg]に動かす
     for joint_name in joint_names:
-        
         # 対象のjointに目標値を設定する
         joint_values_dict[joint_name] = target_joint_value
-        robot_state.joint_positions = joint_values_dict 
-        
+        robot_state.joint_positions = joint_values_dict
+
         joint_constraint = construct_joint_constraint(
             robot_state=robot_state,
-            joint_model_group=crane_x7.get_robot_model().get_joint_model_group('arm'),
+            joint_model_group=crane_x7.get_robot_model().get_joint_model_group(
+                'arm'
+            ),
         )
 
         arm.set_start_state_to_current_state()

--- a/crane_x7_examples_py/crane_x7_examples_py/joint_values.py
+++ b/crane_x7_examples_py/crane_x7_examples_py/joint_values.py
@@ -48,10 +48,9 @@ def main(args=None):
     )
 
     # 動作速度の調整
-    arm_plan_request_params.max_acceleration_scaling_factor = (
-        0.5  # Set 0.0 ~ 1.0
-    )
-    arm_plan_request_params.max_velocity_scaling_factor = 0.5  # Set 0.0 ~ 1.0
+    # Set 0.0 ~ 1.0
+    arm_plan_request_params.max_acceleration_scaling_factor = 0.5
+    arm_plan_request_params.max_velocity_scaling_factor = 0.5
 
     # SRDFに定義されている'vertical'の姿勢にする
     arm.set_start_state_to_current_state()

--- a/crane_x7_examples_py/crane_x7_examples_py/joint_values.py
+++ b/crane_x7_examples_py/crane_x7_examples_py/joint_values.py
@@ -72,15 +72,16 @@ def main(args=None):
         ]
     target_joint_value = math.radians(-45.0)
 
+    # 現在角度をベースに、目標角度を作成する
+    current_state = arm.get_start_state()
+    joint_values = current_state.get_joint_group_positions('arm')
+
+    # jointのリストを辞書型の形式に変換する
+    joint_values_dict = dict(zip(joint_names, joint_values))
+    
     # 各関節角度を順番に-45[deg]に動かす
     for joint_name in joint_names:
-        arm.set_start_state_to_current_state()
-
-        # jointのリストを取得して辞書型の形式に変換する
-        current_state = arm.get_start_state()
-        joint_values = current_state.get_joint_group_positions('arm')
-        joint_values_dict = dict(zip(joint_names, joint_values))
-
+        
         # 対象のjointに目標値を設定する
         joint_values_dict[joint_name] = target_joint_value
         robot_state.joint_positions = joint_values_dict 
@@ -89,6 +90,8 @@ def main(args=None):
             robot_state=robot_state,
             joint_model_group=crane_x7.get_robot_model().get_joint_model_group('arm'),
         )
+
+        arm.set_start_state_to_current_state()
         arm.set_goal_state(motion_plan_constraints=[joint_constraint])
 
         plan_and_execute(

--- a/crane_x7_examples_py/crane_x7_examples_py/joint_values.py
+++ b/crane_x7_examples_py/crane_x7_examples_py/joint_values.py
@@ -72,12 +72,19 @@ def main(args=None):
         ]
     target_joint_value = math.radians(-45.0)
 
-    # 各関節角度を順番に-45[deg]ずつ動かす
+    # 各関節角度を順番に-45[deg]に動かす
     for joint_name in joint_names:
         arm.set_start_state_to_current_state()
 
-        joint_values = {joint_name: target_joint_value}
-        robot_state.joint_positions = joint_values
+        # jointのリストを取得して辞書型の形式に変換する
+        current_state = arm.get_start_state()
+        joint_values = current_state.get_joint_group_positions('arm')
+        joint_values_dict = dict(zip(joint_names, joint_values))
+
+        # 対象のjointに目標値を設定する
+        joint_values_dict[joint_name] = target_joint_value
+        robot_state.joint_positions = joint_values_dict 
+        
         joint_constraint = construct_joint_constraint(
             robot_state=robot_state,
             joint_model_group=crane_x7.get_robot_model().get_joint_model_group('arm'),


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

joint_values.pyサンプルの動作を修正します。
初期状態のjoint値を取得し、その値をもとに目標姿勢を設定するように変更しています。

これにより、たとえば arm.set_goal_state(configuration_name='vertical') の`vertical`を`home`に変更したときに、一瞬だけ`home`の姿勢を取った後すぐに全jointが0になる不具合が解消されます。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

しません。

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

## 環境

- Ubuntu 24.04 Desktop
    - 6.11.0-29-generic 
- ROS 2 Jazzy
- Gazebo Harmonic v 8.9.0

## 手順

Gazeboと実機の両方でテストしました。

### Gazebo

```bash
ros2 launch crane_x7_gazebo crane_x7_with_table.launch.py 
ros2 launch crane_x7_examples_py example.launch.py example:='joint_values' use_sim_time:='true'
```

### 実機

```bash
ros2 launch crane_x7_examples demo.launch.py port_name:=/dev/ttyUSB0
ros2 launch crane_x7_examples_py example.launch.py example:='joint_values
```

# Any other comments?
<!-- その他コメントはありますか？ -->

本修正により、C++版のjoint_valuesサンプルと同じ動作になります。

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
