### PR TITLE
launchファイルの引数にchoicesを追加

### DIFF
--- a/crane_x7_control/launch/crane_x7_control.launch.py
+++ b/crane_x7_control/launch/crane_x7_control.launch.py
@@ -69,18 +69,21 @@ def generate_launch_description():
     declare_use_gazebo = DeclareLaunchArgument(
         'use_gazebo',
         default_value='false',
+        choices=['true', 'false'],
         description='Use gazebo or not.'
     )
 
     declare_use_d435 = DeclareLaunchArgument(
         'use_d435',
         default_value='false',
+        choices=['true', 'false'],
         description='Use d435 or not.'
     )
 
     declare_use_mock_components = DeclareLaunchArgument(
         'use_mock_components',
         default_value='false',
+        choices=['true', 'false'],
         description='Use mock_components or not.'
     )
 

--- a/crane_x7_examples/launch/camera_example.launch.py
+++ b/crane_x7_examples/launch/camera_example.launch.py
@@ -25,15 +25,14 @@ def generate_launch_description():
     declare_example_name = DeclareLaunchArgument(
         'example',
         default_value='color_detection',
-        description=(
-            'Set an example executable name: '
-            '[color_detection, aruco_detection, point_cloud_detection]'
-        ),
+        choices=['color_detection', 'aruco_detection', 'point_cloud_detection'],
+        description='Set an example executable name.',
     )
 
     declare_use_sim_time = DeclareLaunchArgument(
         'use_sim_time',
         default_value='false',
+        choices=['true', 'false'],
         description=('Set true when using the gazebo simulator.'),
     )
 

--- a/crane_x7_examples/launch/demo.launch.py
+++ b/crane_x7_examples/launch/demo.launch.py
@@ -24,7 +24,10 @@ from launch.substitutions import LaunchConfiguration
 
 def generate_launch_description():
     declare_use_d435 = DeclareLaunchArgument(
-        'use_d435', default_value='false', description='Use d435.'
+        'use_d435', 
+        default_value='false',
+        choices=['true', 'false'],
+        description='Use d435.'
     )
 
     declare_rviz_config = DeclareLaunchArgument(

--- a/crane_x7_examples/launch/demo.launch.py
+++ b/crane_x7_examples/launch/demo.launch.py
@@ -24,7 +24,7 @@ from launch.substitutions import LaunchConfiguration
 
 def generate_launch_description():
     declare_use_d435 = DeclareLaunchArgument(
-        'use_d435', 
+        'use_d435',
         default_value='false',
         choices=['true', 'false'],
         description='Use d435.'

--- a/crane_x7_examples/launch/example.launch.py
+++ b/crane_x7_examples/launch/example.launch.py
@@ -25,16 +25,20 @@ def generate_launch_description():
     declare_example_name = DeclareLaunchArgument(
         'example',
         default_value='pose_groupstate',
-        description=(
-            'Set an example executable name: '
-            '[gripper_control, pose_groupstate, joint_values,'
-            'pick_and_place, cartesian_path]'
-        ),
+        choices=[
+            'gripper_control',
+            'pose_groupstate',
+            'joint_values',
+            'pick_and_place',
+            'cartesian_path',
+        ],
+        description='Set an example executable name.',
     )
 
     declare_use_sim_time = DeclareLaunchArgument(
         'use_sim_time',
         default_value='false',
+        choices=['true', 'false'],
         description=('Set true when using the gazebo simulator.'),
     )
 

--- a/crane_x7_examples_py/launch/camera_example.launch.py
+++ b/crane_x7_examples_py/launch/camera_example.launch.py
@@ -25,12 +25,14 @@ def generate_launch_description():
     declare_example_name = DeclareLaunchArgument(
         'example',
         default_value='color_detection',
-        description=('Set an example executable name: [aruco_detection, color_detection]'),
+        choices=['aruco_detection', 'color_detection'],
+        description='Set an example executable name.',
     )
 
     declare_use_sim_time = DeclareLaunchArgument(
         'use_sim_time',
         default_value='false',
+        choices=['true', 'false'],
         description=('Set true when using the gazebo simulator.'),
     )
 

--- a/crane_x7_examples_py/launch/example.launch.py
+++ b/crane_x7_examples_py/launch/example.launch.py
@@ -25,15 +25,14 @@ def generate_launch_description():
     declare_example_name = DeclareLaunchArgument(
         'example',
         default_value='gripper_control',
-        description=(
-            'Set an example executable name: '
-            '[gripper_control, pose_groupstate, joint_values, pick_and_place]'
-        ),
+        choices=['gripper_control', 'pose_groupstate', 'joint_values', 'pick_and_place'],
+        description='Set an example executable name.',
     )
 
     declare_use_sim_time = DeclareLaunchArgument(
         'use_sim_time',
         default_value='false',
+        choices=['true', 'false'],
         description=('Set true when using the gazebo simulator.'),
     )
 

--- a/crane_x7_moveit_config/launch/run_move_group.launch.py
+++ b/crane_x7_moveit_config/launch/run_move_group.launch.py
@@ -68,18 +68,21 @@ def generate_launch_description():
     declare_use_gazebo = DeclareLaunchArgument(
         'use_gazebo',
         default_value='false',
+        choices=['true', 'false'],
         description='Use gazebo or not.'
     )
 
     declare_use_d435 = DeclareLaunchArgument(
         'use_d435',
         default_value='false',
+        choices=['true', 'false'],
         description='Use d435 or not.'
     )
 
     declare_use_mock_components = DeclareLaunchArgument(
         'use_mock_components',
         default_value='false',
+        choices=['true', 'false'],
         description='Use mock_components or not.'
     )
 


### PR DESCRIPTION
## Summary
- `DeclareLaunchArgument` に `choices` を追加し、`example` や `use_gazebo` 等の引数に不正な値が渡された際にros2 launch側でバリデーションされるようにした
- `choices` で選択肢を明示できるようになったため、`description` に手書きしていた選択肢の列挙を削除し簡潔にした

## Test plan
- [ ] 各launchファイルを `ros2 launch` で実行し、デフォルト値で問題なく起動することを確認
- [ ] 存在しない値（例: `example:=invalid_name`）を指定した際にエラーになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)