### PR TITLE
サーボとのsync_read失敗時に通信を継続させる(backport #220)

### DIFF
--- a/crane_x7_control/src/crane_x7_hardware.cpp
+++ b/crane_x7_control/src/crane_x7_hardware.cpp
@@ -230,7 +230,9 @@ return_type CraneX7Hardware::read(
 
   if (!hardware_->sync_read(GROUP_NAME)) {
     RCLCPP_ERROR(LOGGER, "Failed to sync read from servo motors.");
-    return return_type::ERROR;
+    // sync_readに失敗しても通信は継続させる。
+    // 不確かなデータをセットしないようにOKを返す。
+    return return_type::OK;
   }
 
   std::vector<double> positions;


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
#220 と同じ内容のhumbleブランチへの修正です。

サーボとの接続が不安定な場合に、sync_readエラーによるサーボとの通信停止が頻発する不具合がありました。
一時的なsync_readエラーはアームの動作に支障ないため、sync_readエラー時も通信を停止しないように変更します。

1秒以上連続してsync_readエラーが生じた場合はタイムアウトエラーが作動し、通信が停止する実装となっているので、長時間のsync_readエラーによるアームの暴走等は防がれています。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
アーム実機のサーボが正常に動作することを確認しています。

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.